### PR TITLE
Update npmignore file to exclude unnecessary directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+node_modules
+test
+example
+public
+resources
+.github
+.yarn


### PR DESCRIPTION
This pull request updates the npmignore file to exclude unnecessary directories such as node_modules, test, example, public, resources, .github, and .yarn. This will help reduce the size of the repository and improve performance.