### PR TITLE
Refactor ComplexExampleFactory to include AbstractViewport in params

### DIFF
--- a/src/factory/AbstractExampleFactory.ts
+++ b/src/factory/AbstractExampleFactory.ts
@@ -25,6 +25,7 @@ export class AbstractExampleFactory<T> implements ExampleFactor {
             Renderer: WebGLRenderer,
             Editor: AbstractEditor,
             ViewportControls: SimpleViewportControls,
+            Viewport: AbstractViewport,
             container: null,
         };
     }

--- a/src/factory/ComplexExampleFactory.ts
+++ b/src/factory/ComplexExampleFactory.ts
@@ -4,7 +4,6 @@ import { ViewportCameraControls } from '../controls/ViewportCameraControls';
 import { AbstractDebugger } from '../debugger/AbstractDebugger';
 import { NordicGISHelper } from '../gis/NordicGISHelper';
 import { ModelLoader } from '../loader/ModelLoader';
-import { AbstractViewport } from '../viewport/AbstractViewport';
 import { AbstractExampleFactory } from './AbstractExampleFactory';
 import { ExampleFactorParams } from './types';
 
@@ -31,6 +30,7 @@ export class ComplexExampleFactory<T> extends AbstractExampleFactory<T> {
         const KeyboardControls = params.KeyboardControls ?? defaultParams.KeyboardControls;
         const Editor = params.Editor ?? defaultParams.Editor;
         const ViewportControls = params.ViewportControls ?? defaultParams.ViewportControls;
+        const Viewport = params.Viewport ?? defaultParams.Viewport;
 
         const container =
             params.container ?? (document.getElementById('app') as HTMLElement | null);
@@ -74,13 +74,16 @@ export class ComplexExampleFactory<T> extends AbstractExampleFactory<T> {
             // @ts-ignore
             InstanceType<T['KeyboardControls']>;
 
-        const viewport = new AbstractViewport({
+        const viewport = new Viewport({
             container,
             editor,
             renderer,
             viewportControls,
             keyboardControls,
-        });
+        }) as InstanceType<typeof defaultParams.Viewport> &
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            InstanceType<T['Viewport']>;
 
         // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
         const _debugger = new AbstractDebugger({
@@ -101,7 +104,7 @@ export class ComplexExampleFactory<T> extends AbstractExampleFactory<T> {
         };
 
         const GISHelper = new NordicGISHelper();
-        // GISHelper.dev(scene);
+        GISHelper.dev(scene);
         editor.gisHelper = GISHelper;
 
         viewportControls.setBoundary(spatialHashGrid.getBox());

--- a/src/factory/types.ts
+++ b/src/factory/types.ts
@@ -2,6 +2,7 @@ import type { AbstractKeyboardControls } from '../controls/AbstractKeyboardContr
 import type { AbstractViewportControls } from '../controls/AbstractViewportControls';
 import type { AbstractEditor } from '../editor/AbstractEditor';
 import type { AbstractRenderer } from '../renderer/AbstractRenderer';
+import { AbstractViewport } from '../viewport/AbstractViewport';
 
 /**
  * Parameters for the `ExampleFactor`.
@@ -23,6 +24,11 @@ export type ExampleFactorParams = {
      * See {@link AbstractEditor} for more information.
      */
     Editor: typeof AbstractEditor;
+    /**
+     * Custom viewport.
+     * See {@link AbstractViewport} for more information.
+     */
+    Viewport: typeof AbstractViewport;
     /**
      * Custom viewport controls.
      * See {@link AbstractViewportControls} for more information.


### PR DESCRIPTION
The ComplexExampleFactory class has been refactored to include AbstractViewport as a parameter in its constructor. This allows for more flexibility in customizing the viewport used by the factory. The changes include updating the constructor signature, updating the usage of AbstractViewport in the class, and adding the Viewport parameter to the ExampleFactorParams type.