### PR TITLE
Refactor time difference limit for commands in AbstractHistory

### DIFF
--- a/src/history/AbstractHistory.ts
+++ b/src/history/AbstractHistory.ts
@@ -22,12 +22,19 @@ export class AbstractHistory implements History {
 
     config: Config;
 
+    /**
+     * The time difference limit between two commands to be considered as a single command.
+     * @default 500
+     */
+    public timeDifferenceLimit: number;
+
     constructor(editor: Editor) {
         this.editor = editor;
         this.undos = [];
         this.redos = [];
         this.lastCmdTime = Date.now();
         this.idCounter = 0;
+        this.timeDifferenceLimit = 500;
 
         this.historyDisabled = false;
         this.config = editor.config;
@@ -49,7 +56,7 @@ export class AbstractHistory implements History {
             lastCmd.script === _cmd.script &&
             lastCmd.attributeName === _cmd.attributeName;
 
-        if (isUpdatableCmd && timeDifference < 500) {
+        if (isUpdatableCmd && timeDifference < this.timeDifferenceLimit) {
             lastCmd.update(cmd);
             // eslint-disable-next-line no-param-reassign
             cmd = lastCmd; // Warning: Mutation!


### PR DESCRIPTION
"This pull request updates the time difference limit for commands in the AbstractHistory class. Previously, the limit was hardcoded to 500 milliseconds, but now it is configurable through the 'timeDifferenceLimit' property. This allows for more flexibility in determining when two commands should be considered as a single command. The default value remains 500 milliseconds. This change improves the overall functionality and customization options of the AbstractHistory class."