### PR TITLE
Refactor AbstractHistory to enable serialization of commands

### DIFF
--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -4,6 +4,14 @@ import { EditorPointer } from '../editor/types';
 
 export type History = {
     /**
+     * Array of {@link Command | commands} that have been executed.
+     */
+    undos: Command[];
+    /**
+     * Array of {@link Command | commands} that have been undone.
+     */
+    redos: Command[];
+    /**
      * Execute a {@link Command}.
      * @param command {@link Command} to be executed
      * @param optionalName Optional name of the command
@@ -22,6 +30,17 @@ export type History = {
      * @param id State id to go to
      */
     goToState(id: number): void;
+    /**
+     * Enables serialization of commands in the history stack.
+     *
+     * This method ensures that all commands in the undo and redo stacks
+     * are serialized by invoking their `toJSON` method. It temporarily
+     * disables the `sceneGraphChanged` and `historyChanged` signals to
+     * prevent unnecessary updates during the serialization process.
+     *
+     * @param id - The state ID to which the history should be restored after serialization.
+     */
+    enableSerialization(id: number): void;
     fromJSON(json: HistoryJSON): void;
     toJSON(): HistoryJSON;
 } & EditorPointer &


### PR DESCRIPTION
This pull request refactors the AbstractHistory class to enable serialization of commands. It introduces a new method, `enableSerialization`, which ensures that all commands in the undo and redo stacks are serialized by invoking their `toJSON` method. This method temporarily disables the `sceneGraphChanged` and `historyChanged` signals to prevent unnecessary updates during the serialization process.