### PR TITLE
Update display of statsGL and add auto-generated documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ A list of working examples can be found here:
 
 -   [https://andrewisen-tikab.github.io/sej/examples/](https://andrewisen-tikab.github.io/sej/examples/)
 
+## Documentation
+
+Auto-generated documentation can be found here:
+
+-   [https://andrewisen-tikab.github.io/sej/docs/](https://andrewisen-tikab.github.io/sej/docs/)
+
 ## WIP
 
 The purpose of `Sej` is to be "the future of 3D editors".

--- a/src/debugger/AbstractDebugger.ts
+++ b/src/debugger/AbstractDebugger.ts
@@ -27,6 +27,7 @@ export class AbstractDebugger implements Debugger {
         this._enabled = value;
         this.enabled ? this.gui.show() : this.gui.hide();
         this.gameStats.dom.style.display = this.enabled ? 'block' : 'none';
+        this.statsGL.dom.style.display = this.enabled ? 'block' : 'none';
 
         this._previouslyEnabled = this.enabled;
     }


### PR DESCRIPTION
This pull request includes two commits. The first commit updates the display of statsGL based on the debugger enabled state. The second commit adds an auto-generated documentation link to the README.md file. The changes in the code ensure that the statsGL display is shown or hidden based on the debugger enabled state, and provide a link to the auto-generated documentation in the README.md file.