### PR TITLE
Refactor AbstractDebugger to add debug IDs to gameStats and statsGL

### DIFF
--- a/src/debugger/AbstractDebugger.ts
+++ b/src/debugger/AbstractDebugger.ts
@@ -6,7 +6,13 @@ import type { ViewportControls } from '../controls/types';
 import type { SupportedCameras } from '../core/types';
 import type { Editor } from '../editor/types';
 import type { Renderer } from '../renderer/types';
-import { DebugFolders, type DebugParams, type Debugger, defaultDebugParams } from './types';
+import {
+    DEBUG_ID,
+    DebugFolders,
+    type DebugParams,
+    type Debugger,
+    defaultDebugParams,
+} from './types';
 
 export type AbstractDebuggerParams = {
     domElement?: HTMLElement;
@@ -80,10 +86,12 @@ export class AbstractDebugger implements Debugger {
         this.params = { ...defaultDebugParams };
         this.gameStats = new GameStats();
         this.domElement.appendChild(this.gameStats.dom);
+        this.gameStats.dom.id = DEBUG_ID.gameStats;
 
         this.statsGL = new Stats();
         this.statsGL.init(renderer.domElement);
         this.domElement.appendChild(this.statsGL.dom);
+        this.statsGL.dom.id = DEBUG_ID.statsGL;
 
         this.statsGL.dom.style.left = '100px';
 

--- a/src/debugger/types.ts
+++ b/src/debugger/types.ts
@@ -93,3 +93,8 @@ export type AddDebug = {
      */
     addDebug(gui: GUI): void;
 };
+
+export const DEBUG_ID = {
+    gameStats: 'game-stats',
+    statsGL: 'stats-gl',
+} as const;

--- a/src/debugger/types.ts
+++ b/src/debugger/types.ts
@@ -94,7 +94,25 @@ export type AddDebug = {
     addDebug(gui: GUI): void;
 };
 
+/**
+ * An object containing constant identifiers for debugging purposes.
+ * Useful for custom CSS.
+ */
 export const DEBUG_ID = {
+    /**
+     * Identifier for game statistics debugging.
+     *
+     * ```
+     * game-stats
+     * ```
+     */
     gameStats: 'game-stats',
+    /**
+     * Identifier for GL statistics debugging.
+     *
+     * ```
+     * stats-gl
+     * ```
+     */
     statsGL: 'stats-gl',
 } as const;


### PR DESCRIPTION
This pull request refactors the AbstractDebugger class to add debug IDs to the gameStats and statsGL elements. The gameStats element now has the ID "game-stats" and the statsGL element has the ID "stats-gl". This change improves the accessibility and organization of the debugger elements.