### PR TITLE
Refactor error handling in Command interface and AbstractHistory

### DIFF
--- a/src/commands/MultiCommandsCommand.ts
+++ b/src/commands/MultiCommandsCommand.ts
@@ -33,23 +33,27 @@ export class MultiCommandsCommand extends AbstractCommand {
     execute(): void {
         this.editor.signals.sceneGraphChanged.active = false;
 
-        for (let i = 0; i < this.commands.length; i++) {
-            this.commands[i].execute();
+        try {
+            for (let i = 0; i < this.commands.length; i++) {
+                this.commands[i].execute();
+            }
+        } finally {
+            this.editor.signals.sceneGraphChanged.active = true;
+            this.editor.signals.sceneGraphChanged.dispatch();
         }
-
-        this.editor.signals.sceneGraphChanged.active = true;
-        this.editor.signals.sceneGraphChanged.dispatch();
     }
 
     undo(): void {
         this.editor.signals.sceneGraphChanged.active = false;
 
-        for (let i = this.commands.length - 1; i >= 0; i--) {
-            this.commands[i].undo();
+        try {
+            for (let i = this.commands.length - 1; i >= 0; i--) {
+                this.commands[i].undo();
+            }
+        } finally {
+            this.editor.signals.sceneGraphChanged.active = true;
+            this.editor.signals.sceneGraphChanged.dispatch();
         }
-
-        this.editor.signals.sceneGraphChanged.active = true;
-        this.editor.signals.sceneGraphChanged.dispatch();
     }
 
     toJSON(): MultiCommandsCommandJSON {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -25,14 +25,16 @@ export type Command = {
      */
     name: string;
     /**
-     * Execute the command
+     * Execute the command, if possible.
+     * @returns If the command is executed successfully, return `void`. Otherwise, throw an error.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    execute(...args: any[]): void;
+    execute(...args: any[]): void | never;
     /**
      * Undo the command.
+     * @returns If the command is executed successfully, return `void`. Otherwise, throw an error.
      */
-    undo(): void;
+    undo(): void | never;
     json: CommandJSON | undefined;
 } & EditorPointer &
     SerializableObject &

--- a/src/history/AbstractHistory.ts
+++ b/src/history/AbstractHistory.ts
@@ -97,9 +97,12 @@ export class AbstractHistory implements History {
         }
 
         if (cmd !== undefined) {
-            cmd.undo();
-            this.redos.push(cmd);
-            this.editor.signals.historyChanged.dispatch(cmd);
+            try {
+                cmd.undo();
+            } finally {
+                this.redos.push(cmd);
+                this.editor.signals.historyChanged.dispatch(cmd);
+            }
         }
 
         return cmd;
@@ -117,9 +120,12 @@ export class AbstractHistory implements History {
         }
 
         if (cmd !== undefined) {
-            cmd.execute();
-            this.undos.push(cmd);
-            this.editor.signals.historyChanged.dispatch(cmd);
+            try {
+                cmd.execute();
+            } finally {
+                this.undos.push(cmd);
+                this.editor.signals.historyChanged.dispatch(cmd);
+            }
         }
 
         return cmd;

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -23,11 +23,13 @@ export type History = {
      */
     execute: (command: Command, optionalName?: string) => void;
     /**
-     * Undo the last executed {@link Command | command}
+     * Undo the last executed {@link Command | command}.
+     * Will fail if something goes wrong with the {@link Command | command}.
      */
     undo: () => Command | undefined;
     /**
      * Redo the last executed {@link Command | command}
+     * Will fail if something goes wrong with the {@link Command | command}.
      */
     redo: () => void;
     /**


### PR DESCRIPTION
This pull request refactors the Command interface and AbstractHistory to handle error cases in the execute and undo methods. Previously, these methods did not handle errors, which could lead to unexpected behavior. With this refactor, the execute and undo methods now throw an error if something goes wrong, ensuring that errors are properly handled and preventing any potential issues.