### PR TITLE
Update upload-pages-artifact action to v3 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
                   yarn build
                   yarn docs
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v2
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: './dist/examples'
             - name: Deploy to GitHub Pages


### PR DESCRIPTION
Upgrade the upload-pages-artifact action to version 3 for improved functionality in the release workflow.